### PR TITLE
Add quiet option to out script

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,5 @@ Given a Cloudformation configuration file and a AWS stack name, this will apply 
 
 * `capabilities`: *Optional.* Additional CloudFormation capabilities required (example "CAPABILITY_IAM")
   "[Currently, the only valid value is CAPABILITY_IAM](http://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStack.html)"
+
+* `quiet`: *Optional.* Disables trace output from being printed (which may contain credentials).

--- a/bin/out
+++ b/bin/out
@@ -1,7 +1,11 @@
 #!/bin/bash
 
-set -eux
+set -eu
 set -o pipefail
+
+if [ "$(jq -r '.params.quiet' /tmp/input)" != "true" ]; then
+  set -x
+fi
 
 exec 3>&1 # use fd 3 for script output
 exec 1>&2 # send normal stdout to stderr for logging


### PR DESCRIPTION
By default, `out` will `set -x` which causes credentials such as the AWS access key and secret key to be printed.